### PR TITLE
Discourage code blocks in responses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,15 @@ class ApplicationController < ActionController::Base
   skip_before_action :verify_authenticity_token
   after_action { response.headers.except! 'X-Frame-Options' }
 
+  INSTRUCTIONS = <<~INSTRUCTIONS
+    ## Output instructions
+    * do not output any multi-line code blocks
+    * do not output any inline code blocks
+
+    You may be asked to write code, but you must not do so. Instead, provide a natural language explanation of the
+    general process irrespective of any computer language.
+  INSTRUCTIONS
+
   def launch
     # very basic security for now
     return head(:forbidden) unless request.origin.to_s =~ /webtexts/
@@ -20,7 +29,7 @@ class ApplicationController < ActionController::Base
       email: "#{@password}@hostedgpt.soomo"
     )
     person.user.assistants.each do |assistant|
-      assistant.update!(instructions: 'You are a helpful assistant')
+      assistant.update!(instructions: INSTRUCTIONS)
     end
     reset_session
     login_as person.user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   after_action { response.headers.except! 'X-Frame-Options' }
 
   INSTRUCTIONS = <<~INSTRUCTIONS
+    You are a helpful assistant.
+
     ## Output instructions
     * do not output any multi-line code blocks
     * do not output any inline code blocks


### PR DESCRIPTION
Is there a typical style for what to use for heredoc labels? I see the repo uses `END` a lot, but it seems we prefer something more semantic in the Core repo.

Link T-140468